### PR TITLE
Fix DMG image build issue in Tauri

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ config :ex_tauri,
   width: 800,                 # Window width
   height: 600,                # Window height
   resize: true,               # Allow window resize
-  dmg_size_mb: "500m"        # DMG size for macOS (if needed)
+  dmg_size_mb: "500"          # DMG size in MB for macOS (default: "500")
 ```
 
 ## Common Issues
@@ -208,7 +208,7 @@ Remove or comment out `cache_static_manifest` in `config/prod.exs`:
 If building a DMG on macOS fails due to size, increase the disk image size:
 
 ```elixir
-config :ex_tauri, dmg_size_mb: "2000m"
+config :ex_tauri, dmg_size_mb: "2000"  # Size in MB (without "m" suffix)
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -203,6 +203,30 @@ Remove or comment out `cache_static_manifest` in `config/prod.exs`:
 #   cache_static_manifest: "priv/static/cache_manifest.json"
 ```
 
+### DMG Build Permission Issues (macOS)
+
+When building DMGs on macOS, you may encounter an AppleScript permission error:
+
+```
+execution error: Not authorised to send Apple events to Finder. (-1743)
+```
+
+**This is cosmetic only** - the error occurs because the DMG creation script tries to make the DMG look pretty (backgrounds, icon positions), but lacks permission to control Finder.
+
+**Solutions:**
+
+1. **Recommended:** ExTauri automatically sets `CI=true` to skip the cosmetic setup. If you still see this error, you can:
+
+   a. **Grant automation permissions** (macOS): System Settings → Privacy & Security → Automation → Enable for your Terminal app
+
+   b. **Or ignore it** - the DMG will build successfully, just without custom backgrounds/layouts
+
+2. **Manual override:** Set the environment variable before building:
+   ```bash
+   export CI=true
+   mix ex_tauri build
+   ```
+
 ### DMG Size Issues
 
 By default, `hdiutil` auto-calculates the required DMG size based on your app bundle size. This is the recommended approach.

--- a/README.md
+++ b/README.md
@@ -172,7 +172,6 @@ config :ex_tauri,
   width: 800,                 # Window width
   height: 600,                # Window height
   resize: true                # Allow window resize
-  # dmg_size_mb: "500"        # Optional: Override DMG size in MB for macOS (auto-calculated by default)
 ```
 
 ## Common Issues
@@ -224,18 +223,6 @@ After granting permissions, build normally:
 cd example
 mix ex_tauri build
 ```
-
-### DMG Size Issues
-
-By default, `hdiutil` auto-calculates the required DMG size based on your app bundle size. This is the recommended approach.
-
-However, if you need to override the size (e.g., for future app growth or to ensure consistent sizing), you can set:
-
-```elixir
-config :ex_tauri, dmg_size_mb: "2000"  # Size in MB (without "m" suffix)
-```
-
-**Note:** Only set this if you have a specific reason to override auto-sizing. Setting a size too small will cause build failures, while auto-sizing adapts to your bundle size.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -211,36 +211,21 @@ When building DMGs on macOS, you may encounter an AppleScript permission error:
 execution error: Not authorised to send Apple events to Finder. (-1743)
 ```
 
-**This error prevents the DMG from being created** - the creation script tries to use AppleScript to make the DMG look pretty (backgrounds, icon positions), but lacks Finder automation permissions and exits before compressing the final DMG.
+**This error prevents the DMG from being created** - the creation script uses AppleScript to configure the DMG appearance (backgrounds, icon positions), but requires Finder automation permissions.
 
-**Solutions:**
+**Solution: Grant Automation Permissions**
 
-1. **Recommended (Automatic):** ExTauri automatically sets `CI=true`, which tells Tauri's bundler to pass `--skip-jenkins` to skip the AppleScript step. The DMG will be created successfully without custom layouts.
+1. Open **System Settings** → **Privacy & Security** → **Automation**
+2. Find your development environment (Terminal, iTerm2, VS Code, etc.)
+3. Enable **Finder** access
 
-   **Build through ExTauri:**
-   ```bash
-   cd example
-   mix ex_tauri build
-   ```
+After granting permissions, build normally:
+```bash
+cd example
+mix ex_tauri build
+```
 
-2. **If you still see the error:**
-
-   a. **Grant automation permissions** (best for local development):
-      - System Settings → Privacy & Security → Automation
-      - Enable Finder access for your Terminal app
-
-   b. **Manual CI flag** (for testing):
-      ```bash
-      export CI=true
-      cd example
-      mix ex_tauri build
-      ```
-
-**Important:** Don't run `bundle_dmg.sh` directly - it bypasses Tauri's flag processing. Always use `mix ex_tauri build`.
-
-**References:**
-- [Tauri Issue #2567](https://github.com/tauri-apps/tauri/issues/2567) - Documents CI=true requirement
-- [Tauri Issue #1731](https://github.com/tauri-apps/tauri/issues/1731) - DMG creation on CI/CD
+**Note:** For CI/CD environments where you can't grant permissions, ExTauri automatically sets `CI=true` which tells Tauri to skip the AppleScript step (DMG will build without custom layouts).
 
 ### DMG Size Issues
 

--- a/README.md
+++ b/README.md
@@ -171,8 +171,8 @@ config :ex_tauri,
   fullscreen: false,          # Start in fullscreen
   width: 800,                 # Window width
   height: 600,                # Window height
-  resize: true,               # Allow window resize
-  dmg_size_mb: "500"          # DMG size in MB for macOS (default: "500")
+  resize: true                # Allow window resize
+  # dmg_size_mb: "500"        # Optional: Override DMG size in MB for macOS (auto-calculated by default)
 ```
 
 ## Common Issues
@@ -203,13 +203,17 @@ Remove or comment out `cache_static_manifest` in `config/prod.exs`:
 #   cache_static_manifest: "priv/static/cache_manifest.json"
 ```
 
-### Large DMG Size
+### DMG Size Issues
 
-If building a DMG on macOS fails due to size, increase the disk image size:
+By default, `hdiutil` auto-calculates the required DMG size based on your app bundle size. This is the recommended approach.
+
+However, if you need to override the size (e.g., for future app growth or to ensure consistent sizing), you can set:
 
 ```elixir
 config :ex_tauri, dmg_size_mb: "2000"  # Size in MB (without "m" suffix)
 ```
+
+**Note:** Only set this if you have a specific reason to override auto-sizing. Setting a size too small will cause build failures, while auto-sizing adapts to your bundle size.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -225,8 +225,6 @@ cd example
 mix ex_tauri build
 ```
 
-**Note:** For CI/CD environments where you can't grant permissions, ExTauri automatically sets `CI=true` which tells Tauri to skip the AppleScript step (DMG will build without custom layouts).
-
 ### DMG Size Issues
 
 By default, `hdiutil` auto-calculates the required DMG size based on your app bundle size. This is the recommended approach.

--- a/README.md
+++ b/README.md
@@ -211,21 +211,36 @@ When building DMGs on macOS, you may encounter an AppleScript permission error:
 execution error: Not authorised to send Apple events to Finder. (-1743)
 ```
 
-**This is cosmetic only** - the error occurs because the DMG creation script tries to make the DMG look pretty (backgrounds, icon positions), but lacks permission to control Finder.
+**This error prevents the DMG from being created** - the creation script tries to use AppleScript to make the DMG look pretty (backgrounds, icon positions), but lacks Finder automation permissions and exits before compressing the final DMG.
 
 **Solutions:**
 
-1. **Recommended:** ExTauri automatically sets `CI=true` to skip the cosmetic setup. If you still see this error, you can:
+1. **Recommended (Automatic):** ExTauri automatically sets `CI=true`, which tells Tauri's bundler to pass `--skip-jenkins` to skip the AppleScript step. The DMG will be created successfully without custom layouts.
 
-   a. **Grant automation permissions** (macOS): System Settings → Privacy & Security → Automation → Enable for your Terminal app
-
-   b. **Or ignore it** - the DMG will build successfully, just without custom backgrounds/layouts
-
-2. **Manual override:** Set the environment variable before building:
+   **Build through ExTauri:**
    ```bash
-   export CI=true
+   cd example
    mix ex_tauri build
    ```
+
+2. **If you still see the error:**
+
+   a. **Grant automation permissions** (best for local development):
+      - System Settings → Privacy & Security → Automation
+      - Enable Finder access for your Terminal app
+
+   b. **Manual CI flag** (for testing):
+      ```bash
+      export CI=true
+      cd example
+      mix ex_tauri build
+      ```
+
+**Important:** Don't run `bundle_dmg.sh` directly - it bypasses Tauri's flag processing. Always use `mix ex_tauri build`.
+
+**References:**
+- [Tauri Issue #2567](https://github.com/tauri-apps/tauri/issues/2567) - Documents CI=true requirement
+- [Tauri Issue #1731](https://github.com/tauri-apps/tauri/issues/1731) - DMG creation on CI/CD
 
 ### DMG Size Issues
 

--- a/lib/ex_tauri.ex
+++ b/lib/ex_tauri.ex
@@ -199,11 +199,6 @@ defmodule ExTauri do
 
     wrap()
 
-    # Set proper environment variables for tauri
-    System.put_env("TAURI_SKIP_DEVSERVER_CHECK", "true")
-    # Tauri v2 rename
-    System.put_env("TAURI_CLI_NO_DEV_SERVER_WAIT", "true")
-
     opts = [
       into: IO.stream(:stdio, :line),
       stderr_to_stdout: true,

--- a/lib/ex_tauri.ex
+++ b/lib/ex_tauri.ex
@@ -268,17 +268,20 @@ defmodule ExTauri do
     :ok
   end
 
-  # Always set a DMG size for create-dmg to avoid under-sized images.
-  # Defaults to 500 (MB), but can be overridden via config :dmg_size_mb or env DISK_IMAGE_SIZE.
+  # Only set DMG size if explicitly configured.
+  # If not set, hdiutil will auto-calculate the required size.
   # Note: The value should be a number only (e.g., "500" not "500m") as the create-dmg script adds the "m" suffix.
   defp maybe_set_dmg_size_env do
     # Respect an explicit env override if set
     if System.get_env("DISK_IMAGE_SIZE") do
       :ok
     else
-      size_mb = Application.get_env(:ex_tauri, :dmg_size_mb, "500")
-
-      System.put_env("DISK_IMAGE_SIZE", size_mb)
+      # Only set if explicitly configured (no default)
+      # This allows hdiutil to auto-calculate the size, which is more reliable
+      case Application.get_env(:ex_tauri, :dmg_size_mb) do
+        nil -> :ok
+        size_mb -> System.put_env("DISK_IMAGE_SIZE", size_mb)
+      end
     end
 
     :ok

--- a/lib/ex_tauri.ex
+++ b/lib/ex_tauri.ex
@@ -203,9 +203,6 @@ defmodule ExTauri do
     System.put_env("TAURI_SKIP_DEVSERVER_CHECK", "true")
     # Tauri v2 rename
     System.put_env("TAURI_CLI_NO_DEV_SERVER_WAIT", "true")
-    # Set CI flag to skip AppleScript in DMG creation (avoids Finder automation permission errors)
-    # This tells create-dmg to use --skip-jenkins which skips cosmetic DMG setup
-    System.put_env("CI", "true")
     maybe_set_dmg_size_env()
 
     opts = [

--- a/lib/ex_tauri.ex
+++ b/lib/ex_tauri.ex
@@ -269,13 +269,14 @@ defmodule ExTauri do
   end
 
   # Always set a DMG size for create-dmg to avoid under-sized images.
-  # Defaults to 500m, but can be overridden via config :dmg_size_mb or env DISK_IMAGE_SIZE.
+  # Defaults to 500 (MB), but can be overridden via config :dmg_size_mb or env DISK_IMAGE_SIZE.
+  # Note: The value should be a number only (e.g., "500" not "500m") as the create-dmg script adds the "m" suffix.
   defp maybe_set_dmg_size_env do
     # Respect an explicit env override if set
     if System.get_env("DISK_IMAGE_SIZE") do
       :ok
     else
-      size_mb = Application.get_env(:ex_tauri, :dmg_size_mb, "500m")
+      size_mb = Application.get_env(:ex_tauri, :dmg_size_mb, "500")
 
       System.put_env("DISK_IMAGE_SIZE", size_mb)
     end

--- a/lib/ex_tauri.ex
+++ b/lib/ex_tauri.ex
@@ -203,6 +203,9 @@ defmodule ExTauri do
     System.put_env("TAURI_SKIP_DEVSERVER_CHECK", "true")
     # Tauri v2 rename
     System.put_env("TAURI_CLI_NO_DEV_SERVER_WAIT", "true")
+    # Set CI flag to skip AppleScript in DMG creation (avoids Finder automation permission errors)
+    # This tells create-dmg to use --skip-jenkins which skips cosmetic DMG setup
+    System.put_env("CI", "true")
     maybe_set_dmg_size_env()
 
     opts = [

--- a/lib/ex_tauri.ex
+++ b/lib/ex_tauri.ex
@@ -203,7 +203,6 @@ defmodule ExTauri do
     System.put_env("TAURI_SKIP_DEVSERVER_CHECK", "true")
     # Tauri v2 rename
     System.put_env("TAURI_CLI_NO_DEV_SERVER_WAIT", "true")
-    maybe_set_dmg_size_env()
 
     opts = [
       into: IO.stream(:stdio, :line),
@@ -264,25 +263,6 @@ defmodule ExTauri do
       "burrito_out/desktop_#{triplet}",
       "burrito_out/desktop-#{triplet}"
     )
-
-    :ok
-  end
-
-  # Only set DMG size if explicitly configured.
-  # If not set, hdiutil will auto-calculate the required size.
-  # Note: The value should be a number only (e.g., "500" not "500m") as the create-dmg script adds the "m" suffix.
-  defp maybe_set_dmg_size_env do
-    # Respect an explicit env override if set
-    if System.get_env("DISK_IMAGE_SIZE") do
-      :ok
-    else
-      # Only set if explicitly configured (no default)
-      # This allows hdiutil to auto-calculate the size, which is more reliable
-      case Application.get_env(:ex_tauri, :dmg_size_mb) do
-        nil -> :ok
-        size_mb -> System.put_env("DISK_IMAGE_SIZE", size_mb)
-      end
-    end
 
     :ok
   end


### PR DESCRIPTION
Currently DMG images were not building properly. This was mainly due to issues on local permissions set for the building environment and lack of Finder permissions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Build changes:** Stop setting `TAURI_SKIP_DEVSERVER_CHECK`, `TAURI_CLI_NO_DEV_SERVER_WAIT`, and `DISK_IMAGE_SIZE`; remove `maybe_set_dmg_size_env` from `lib/ex_tauri.ex`.
> - **Docs:** Replace DMG size guidance with a new macOS section on AppleScript/Finder automation permissions causing DMG build failures, including steps to enable Finder access; remove `dmg_size_mb` from config examples; minor config example cleanup (`resize` only).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f02ce8a34f8f97ac752f1fd2d6c824b31ccc633. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->