### PR TITLE
Improve architecture, documentation, and cross-platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,59 @@ Your app bundle will be at `src-tauri/target/release/bundle/` with platform-spec
 
 Run `mix help ex_tauri.<task>` for detailed options.
 
+## Using Desktop APIs
+
+ExTauri provides Elixir modules for common desktop features. Some are included
+by default, others require installing additional Tauri plugins.
+
+### Included by default
+
+These work out of the box after `mix ex_tauri.install`:
+
+- **`ExTauri.Notification`** — Native desktop notifications
+- **`ExTauri.Shell`** — Open URLs, execute scoped commands
+
+### Requires additional plugin setup
+
+These modules need a Tauri plugin added to your `src-tauri/` project.
+See each module's documentation for setup instructions.
+
+- **`ExTauri.Dialog`** — File open/save dialogs, message boxes
+- **`ExTauri.Clipboard`** — Read/write the system clipboard
+- **`ExTauri.Filesystem`** — Read/write files outside the web sandbox
+- **`ExTauri.OS`** — Query platform, architecture, locale
+
+### Example: sending a notification from LiveView
+
+```elixir
+def handle_event("notify", _params, socket) do
+  socket = ExTauri.Notification.send(socket, "Saved!", body: "Your file was saved.")
+  {:noreply, socket}
+end
+
+def handle_event("tauri_response", %{"command" => "notification", "status" => status}, socket) do
+  {:noreply, assign(socket, :notification_status, status)}
+end
+```
+
+### Example: opening a file dialog
+
+First, install `tauri-plugin-dialog` (see `ExTauri.Dialog` docs), then:
+
+```elixir
+def handle_event("open_file", _params, socket) do
+  socket = ExTauri.Dialog.open(socket,
+    title: "Select a file",
+    filters: [%{name: "Text", extensions: ["txt", "md"]}]
+  )
+  {:noreply, socket}
+end
+
+def handle_event("tauri_response", %{"command" => "dialog_open", "path" => path}, socket) do
+  {:noreply, assign(socket, :selected_file, path)}
+end
+```
+
 ## How It Works
 
 ### Architecture
@@ -209,13 +262,44 @@ Desktop apps need a local database path. Configure in `config/runtime.exs`:
 ```elixir
 database_path =
   System.get_env("DATABASE_PATH") ||
-    Path.join([System.user_home!(), ".my_app", "my_app.db"])
-
-File.mkdir_p!(Path.dirname(database_path))
+    Path.join([ExTauri.Paths.data_dir(), "my_app.db"])
 
 config :my_app, MyApp.Repo,
   database: database_path,
   pool_size: 5
+```
+
+### Running Ecto migrations in a desktop release
+
+Desktop releases don't run `mix ecto.migrate`. Add a release module that
+runs migrations on startup:
+
+```elixir
+# lib/my_app/release.ex
+defmodule MyApp.Release do
+  def migrate do
+    for repo <- repos() do
+      {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))
+    end
+  end
+
+  defp repos, do: Application.fetch_env!(:my_app, :ecto_repos)
+end
+```
+
+Then call it early in your `application.ex` startup:
+
+```elixir
+def start(_type, _args) do
+  MyApp.Release.migrate()
+
+  children = [
+    MyApp.Repo,
+    ExTauri.ShutdownManager,
+    # ...
+  ]
+  # ...
+end
 ```
 
 ### Static assets in production

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,4 +1,4 @@
-# ExTauri Library Review: Missing Features & Release Readiness
+# ExTauri Library Review: Current State & Remaining Work
 
 ## Current State
 
@@ -7,143 +7,71 @@ ExTauri provides:
 - Mix tasks: `install`, `dev`, `build`, `info`, `icon`, `signer`
 - Heartbeat-based graceful shutdown via Unix domain sockets
 - Window configuration (title, size, fullscreen, resize)
-- Tauri plugins: `log` and `shell`
+- LiveView JS hook bridge for Tauri API access
+- Elixir API modules: Notification, Shell, Dialog, Clipboard, Filesystem, OS
+- Platform-appropriate path resolution (macOS, Linux, Windows)
+- Updater configuration and signing support
+- Proper OTP supervision tree with Task.Supervisor
 
-This is essentially **scaffolding + lifecycle management**. The library generates Rust boilerplate and manages the build pipeline, but provides no Elixir-side APIs for desktop-specific functionality.
+## Resolved Issues
 
----
+The following issues from prior reviews have been addressed:
 
-## Missing Features
-
-### 1. Filesystem Utilities
-
-Desktop apps need local filesystem access beyond what Elixir's `File` module provides:
-
-- **App data directories** — No helper for platform-appropriate paths (`~/Library/Application Support/` on macOS, `~/.local/share/` on Linux). The example hardcodes `System.user_home!()`. Tauri has `tauri-plugin-fs` and path resolution APIs that are not wired up.
-- **File dialogs** — No open/save file dialog. Tauri has `tauri-plugin-dialog` for native file pickers. Users have no way to let end-users select files from the Elixir side.
-- **Drag and drop** — Tauri supports drag-and-drop events but there's no bridge to Phoenix/LiveView.
-
-**Recommendation**: An `ExTauri.Paths` module resolving platform-appropriate directories (`data_dir/0`, `config_dir/0`, `cache_dir/0`, `log_dir/0`) and an `ExTauri.Dialog` module for file open/save via Tauri commands.
-
-### 2. Network Utilities
-
-- **Deep linking / custom URL schemes** — Tauri has `tauri-plugin-deep-link`. Desktop apps commonly need `myapp://` URL handling for OAuth callbacks and inter-app communication.
-- **Tauri command/event bridge** — The only communication channel is the WebView loading Phoenix over HTTP. There's no way to send structured messages between Rust and Elixir outside of the heartbeat socket.
-
-**Recommendation**: Document that network operations should use Elixir libraries directly (`:httpc`, Req, Finch). Add deep-link support for OAuth flows.
-
-### 3. Notification Utilities
-
-- **System notifications** — Tauri has `tauri-plugin-notification` for native OS notifications. Currently there's no way to send desktop notifications from Elixir/Phoenix code.
-- **System tray** — Tauri V2 supports system tray icons and menus. No integration exists. Important for apps that minimize to tray.
-
-**Recommendation**: `ExTauri.Notification` module for native notifications and `ExTauri.Tray` for system tray management, both via a Tauri command bridge.
-
-### 4. OS-Specific Utilities
-
-- **Clipboard** — Tauri has `tauri-plugin-clipboard-manager`. No integration.
-- **Global shortcuts** — Tauri has `tauri-plugin-global-shortcut`. No integration.
-- **OS info** — Tauri has `tauri-plugin-os` for platform detection, locale, etc.
-- **Single instance** — Tauri has `tauri-plugin-single-instance` to prevent multiple app instances. Important for desktop apps with local databases.
-- **Autostart** — Tauri has `tauri-plugin-autostart` for launch-at-login.
-- **Window management** — Beyond initial config (width/height/fullscreen), there's no runtime window control (minimize, maximize, set title, open new windows, multi-window).
-
-**Recommendation**: Priority order: single-instance > clipboard > global shortcuts > autostart > OS info.
-
-### 5. Upgradability / Auto-Update
-
-- The `signer` mix task exists for code signing, but **there's no actual updater integration**. Tauri has `tauri-plugin-updater` supporting check/download/apply updates.
-- No update server configuration or manifest generation.
-- No documentation on how to set up an update workflow (GitHub Releases, S3, custom server).
-
-**Recommendation**: Wire up `tauri-plugin-updater` in the generated Rust code. Add `ExTauri.Updater` config for update endpoint URL and public key. Consider a `mix ex_tauri.release` task that builds + signs + generates update manifests.
+| Issue | Resolution |
+|-------|------------|
+| No Tauri Command Bridge | LiveView JS hook (`TauriHook`) bridges all Tauri plugin APIs |
+| No `ExTauri.Paths` module | Added with macOS, Linux, and Windows support + XDG compliance |
+| No file dialogs | `ExTauri.Dialog` module with open/save/message/confirm/ask |
+| No system notifications | `ExTauri.Notification` module |
+| No clipboard support | `ExTauri.Clipboard` module |
+| No filesystem access | `ExTauri.Filesystem` module |
+| No OS info | `ExTauri.OS` module |
+| Wrong MixProject name | Fixed to `ExTauri.MixProject` |
+| Missing `mod:` in application | Fixed — `ExTauri` implements `Application` with proper supervisor |
+| Hardcoded `/tmp/` | Uses `System.tmp_dir!/0` |
+| Empty supervisor | Now supervises `ExTauri.TaskSupervisor` for socket accept tasks |
+| macOS-only Burrito cache nuke | Removed — Burrito handles its own cache |
+| `build.rs` copy hack | Removed — Cargo.toml now uses the default `build.rs` location |
+| Inline Rust template | Moved to `priv/templates/main.rs.eex` |
+| Updater not wired into build | `ExTauri.Updater.tauri_config/0` merged into `tauri.conf.json` |
+| No plugin setup docs | Each API module documents Cargo.toml, main.rs, and capabilities setup |
+| No ref-based response correlation | `ExTauri.Hook.push_command_tracked/4` for concurrent command disambiguation |
+| No migration guidance | README documents release migration pattern for Ecto apps |
+| No Windows paths | `ExTauri.Paths` handles `%APPDATA%` and `%LOCALAPPDATA%` |
 
 ---
 
-## Windows Support Analysis
+## Remaining Work
 
-### Assumption: "Windows requires more work due to lack of Burrito support"
+### P0 — Critical for Production Use
 
-**Partially correct, but the blocker is ExTauri's architecture, not Burrito.**
+| Feature | Details |
+|---------|---------|
+| Windows heartbeat IPC | `ShutdownManager` uses Unix domain sockets. Windows needs named pipes or TCP localhost. The Rust template has a `#[cfg(windows)]` stub but no implementation. |
+| CI/CD pipeline | No GitHub Actions. Need: test matrix (OTP 27, Elixir 1.15+), Rust compilation check, Credo/Dialyzer. |
 
-Burrito itself **does** support Windows — it can produce Windows executables. The blockers are:
+### P1 — Important for Adoption
 
-1. **Unix domain sockets** — The heartbeat mechanism uses `std::os::unix::net::UnixStream` in Rust (`lib/mix/tasks/ex_tauri.install.ex:430`) which **will not compile on Windows**.
-2. **Hardcoded `/tmp/` paths** — Socket path `/tmp/tauri_heartbeat_<name>.sock` doesn't exist on Windows.
-3. **Elixir ShutdownManager** — Uses `{:ifaddr, {:local, socket_path}}` for Unix domain sockets.
-4. **SIGTERM** — The graceful shutdown uses `kill -TERM` which is Unix-only. The Rust side has a `#[cfg(windows)]` fallback that just sleeps 2 seconds — incomplete.
+| Feature | Details |
+|---------|---------|
+| Hex publication | Currently git-only dependency. Needs `package` config in mix.exs, hex docs. |
+| System tray | Tauri V2 supports tray icons/menus. No integration exists. Important for long-running desktop apps. |
+| Deep linking | `tauri-plugin-deep-link` for `myapp://` URL handling (OAuth, inter-app). |
+| Global shortcuts | `tauri-plugin-global-shortcut` for app-wide keyboard shortcuts. |
 
-**To support Windows**: Named pipes or TCP localhost sockets, `%APPDATA%` paths, and a Windows-compatible IPC mechanism would all be needed. This is non-trivial and deferring it is the right call.
+### P2 — Nice to Have
 
----
+| Feature | Details |
+|---------|---------|
+| Autostart | `tauri-plugin-autostart` for launch-at-login. |
+| Runtime window management | Beyond initial config — minimize, maximize, set title, multi-window from LiveView. |
+| Drag and drop | Tauri supports DnD events but no bridge to LiveView. |
+| Compile-time config validation | Catch missing `:host`/`:port` at compile time, not runtime. |
 
-## Architectural Gaps
+### Architecture Considerations
 
-### No Tauri Command Bridge (Critical)
+1. **Dev mode builds full Burrito release** — `mix ex_tauri.dev` calls `wrap/0` which builds a production release every time. Consider a lighter dev path that skips Burrito wrapping and builds a standard release.
 
-The biggest gap: **no bidirectional communication between Elixir and Tauri beyond HTTP**.
+2. **Single hook element bottleneck** — All Tauri commands flow through one `<div id="tauri-bridge">`. If re-rendered, the bridge disconnects. Consider documenting this constraint and potential mitigations.
 
-- Tauri → Phoenix: WebView loads HTTP pages (works)
-- Phoenix → Tauri: **Nothing** (no way to invoke Tauri APIs from Elixir)
-
-All missing features (notifications, clipboard, dialogs, etc.) require a **command bridge**. Options:
-- Extend the existing heartbeat socket to be bidirectional with JSON commands
-- A LiveView JS hook that forwards calls to Tauri's `invoke()` API
-- A dedicated WebSocket channel for structured commands
-
-This is the **single most impactful improvement** — it unlocks all plugin integrations.
-
----
-
-## Other Issues
-
-### Code Quality
-
-| Issue | Location | Details |
-|-------|----------|---------|
-| Wrong MixProject name | `mix.exs:1` | `Desktop.MixProject` should be `ExTauri.MixProject` |
-| Missing `mod:` in application | `mix.exs:17` | `ExTauri` has `use Application` but `mod:` is not set, so `start/2` is never called |
-| Hardcoded `/tmp/` | `shutdown_manager.ex:67` | Should use `System.tmp_dir!/0` for portability |
-| Hardcoded sidecar name | `ex_tauri.install.ex:170` | `burrito_out/desktop` is not configurable |
-| TODO workaround | `ex_tauri.install.ex:157-161` | `build.rs` copy hack with comment "remove this when possible" |
-
-### Testing
-
-- Tests are mostly documentation-style assertions (testing string contents of hardcoded docs)
-- No tests for `ShutdownManager` behavior
-- No tests for mix tasks
-- `BuildReleaseTest` tests literal documentation strings, not actual behavior
-- Integration tests call `ExTauri.__test_*` functions that don't appear to be defined
-
-### Infrastructure
-
-- **No CI/CD** — No GitHub Actions or CI configuration
-- **No Hex package** — Only available via git dependency
-- **No config validation** — Missing `:host`/`:port` only discovered at `mix ex_tauri.install` runtime
-
-### Missing LiveView Integration
-
-Since the primary use case is Phoenix LiveView, there should be:
-- A LiveView JS hook for Tauri interop (calling `window.__TAURI__` APIs)
-- A JS hook for passing Tauri events to LiveView (window focus/blur, system theme changes)
-
----
-
-## Recommended Priority for Release
-
-| Priority | Feature | Impact |
-|----------|---------|--------|
-| **P0** | Tauri Command Bridge (architecture) | Unlocks all plugin integrations |
-| **P0** | Fix MixProject naming + `mod:` config | Correctness |
-| **P1** | `ExTauri.Paths` — platform app directories | Basic desktop requirement |
-| **P1** | Single Instance plugin | Prevents data corruption |
-| **P1** | File Dialogs | Basic desktop UX expectation |
-| **P1** | System Notifications | Basic desktop UX expectation |
-| **P2** | Auto-Updater integration | Critical for distribution |
-| **P2** | System Tray | Expected for long-running desktop apps |
-| **P2** | LiveView JS hooks for Tauri interop | Developer experience |
-| **P3** | CI/CD pipeline | Project maintenance |
-| **P3** | Publish to Hex | Adoption |
-| **P3** | Config validation at compile time | Developer experience |
-| **P3** | Replace hardcoded `/tmp/` with `System.tmp_dir!/0` | Portability |
-| **Deferred** | Windows support | Requires architectural changes to IPC |
+3. **OTP 27 hard constraint** — Burrito's pre-compiled ERTS limits OTP version. Document upgrade path and track Burrito's OTP 28 support.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -38,6 +38,9 @@ The following issues from prior reviews have been addressed:
 | No ref-based response correlation | `ExTauri.Hook.push_command_tracked/4` for concurrent command disambiguation |
 | No migration guidance | README documents release migration pattern for Ecto apps |
 | No Windows paths | `ExTauri.Paths` handles `%APPDATA%` and `%LOCALAPPDATA%` |
+| Dev mode uses full Burrito build | `run_dev/1` builds standard release with shell wrapper sidecar |
+| TauriHook fragile on re-render | Added `reconnected()`, `destroyed()` lifecycle callbacks |
+| OTP version constraint hidden | `validate_config` and `preflight_check!` surface clear OTP warnings |
 
 ---
 
@@ -68,10 +71,10 @@ The following issues from prior reviews have been addressed:
 | Drag and drop | Tauri supports DnD events but no bridge to LiveView. |
 | Compile-time config validation | Catch missing `:host`/`:port` at compile time, not runtime. |
 
-### Architecture Considerations
+### Architecture Considerations (Resolved)
 
-1. **Dev mode builds full Burrito release** — `mix ex_tauri.dev` calls `wrap/0` which builds a production release every time. Consider a lighter dev path that skips Burrito wrapping and builds a standard release.
+1. ~~**Dev mode builds full Burrito release**~~ — Fixed. `mix ex_tauri.dev` now uses `run_dev/1` which builds a standard release and creates a shell wrapper script at the sidecar path. Burrito wrapping is only used by `mix ex_tauri.build` for production.
 
-2. **Single hook element bottleneck** — All Tauri commands flow through one `<div id="tauri-bridge">`. If re-rendered, the bridge disconnects. Consider documenting this constraint and potential mitigations.
+2. ~~**Single hook element bottleneck**~~ — Mitigated. `TauriHook` now implements `reconnected()` and `destroyed()` lifecycle callbacks. Commands in flight when the hook is destroyed are safely dropped. Reconnection re-attaches the event handler automatically.
 
-3. **OTP 27 hard constraint** — Burrito's pre-compiled ERTS limits OTP version. Document upgrade path and track Burrito's OTP 28 support.
+3. ~~**OTP 27 hard constraint**~~ — Surfaced. `validate_config/0` and `preflight_check!/0` both check the OTP version and emit clear warnings/errors explaining the Burrito ERTS constraint and how to install OTP 27.

--- a/lib/ex_tauri.ex
+++ b/lib/ex_tauri.ex
@@ -17,7 +17,12 @@ defmodule ExTauri do
   @doc false
   def start(_, _) do
     validate_config()
-    Supervisor.start_link([], strategy: :one_for_one)
+
+    children = [
+      {Task.Supervisor, name: ExTauri.TaskSupervisor}
+    ]
+
+    Supervisor.start_link(children, strategy: :one_for_one, name: ExTauri.Supervisor)
   end
 
   defp validate_config do
@@ -147,13 +152,6 @@ defmodule ExTauri do
   end
 
   defp wrap() do
-    # Clear Burrito's cached ERTS to force a fresh download (macOS-specific path)
-    burrito_cache = Path.join([Path.expand("~"), "Library", "Application Support", ".burrito"])
-
-    if File.dir?(burrito_cache) do
-      File.rm_rf!(burrito_cache)
-    end
-
     get_in(Mix.Project.config(), [:releases, :desktop]) ||
       raise "expected a burrito release configured for the app :desktop in your mix.exs"
 

--- a/lib/ex_tauri.ex
+++ b/lib/ex_tauri.ex
@@ -26,6 +26,30 @@ defmodule ExTauri do
   end
 
   defp validate_config do
+    otp_release = :erlang.system_info(:otp_release) |> List.to_string()
+
+    case Integer.parse(otp_release) do
+      {major, _} when major < 27 ->
+        Logger.warning("""
+        ExTauri requires OTP 27 but you are running OTP #{otp_release}.
+        Burrito does not have pre-compiled ERTS available for other OTP versions.
+
+        Install OTP 27 via asdf, mise, or kerl:
+
+            asdf install erlang 27.2
+        """)
+
+      {major, _} when major > 27 ->
+        Logger.warning("""
+        ExTauri currently targets OTP 27 but you are running OTP #{otp_release}.
+        Burrito may not have pre-compiled ERTS for OTP #{major} yet.
+        Production builds may fail. Development should work if Burrito is skipped.
+        """)
+
+      _ ->
+        :ok
+    end
+
     unless Application.get_env(:ex_tauri, :version) do
       Logger.warning("""
       tauri version is not configured. Please set it in your config files:
@@ -73,37 +97,43 @@ defmodule ExTauri do
   end
 
   @doc """
-  Runs a Tauri CLI command with the given arguments.
+  Runs a Tauri CLI command after building a full production release.
 
-  This function builds the Elixir release using Burrito, then executes
-  the Tauri CLI with the provided arguments. Use this for commands that
-  require a sidecar binary (dev, build).
+  This function builds the Elixir release (with Burrito wrapping), then
+  executes the Tauri CLI. Use this for production builds only.
 
-  For commands that don't need the release build, use `run_simple/1`.
+  For development, use `run_dev/1` which skips Burrito for faster iteration.
+  For commands that don't need a release at all, use `run_simple/1`.
 
   ## Examples
 
-      ExTauri.run(["dev"])
       ExTauri.run(["build", "--target", "x86_64-apple-darwin"])
 
   """
   def run(args) when is_list(args) do
-    # Verify we're in a directory with src-tauri before proceeding
-    unless File.dir?("src-tauri") do
-      raise """
-      Could not find src-tauri directory in the current path: #{File.cwd!()}
-
-      Make sure you:
-      1. Run this command from your project root (where mix.exs is located)
-      2. Have run 'mix ex_tauri.install' to set up the Tauri project structure
-
-      If you're in the ex_tauri repository root, try:
-        cd example
-        mix ex_tauri.build
-      """
-    end
-
+    check_src_tauri!()
     wrap()
+    run_tauri_cli(args)
+  end
+
+  @doc """
+  Runs a Tauri CLI command after building a lightweight development release.
+
+  Unlike `run/1`, this skips Burrito wrapping and builds a standard Elixir
+  release. This is significantly faster for development iteration since it
+  avoids downloading and packaging ERTS on every change.
+
+  The sidecar binary is placed at the same path Tauri expects, so the
+  native window works identically.
+
+  ## Examples
+
+      ExTauri.run_dev(["dev", "--no-dev-server-wait"])
+
+  """
+  def run_dev(args) when is_list(args) do
+    check_src_tauri!()
+    wrap_dev()
     run_tauri_cli(args)
   end
 
@@ -151,9 +181,25 @@ defmodule ExTauri do
     end
   end
 
+  defp check_src_tauri! do
+    unless File.dir?("src-tauri") do
+      raise """
+      Could not find src-tauri directory in the current path: #{File.cwd!()}
+
+      Make sure you:
+      1. Run this command from your project root (where mix.exs is located)
+      2. Have run 'mix ex_tauri.install' to set up the Tauri project structure
+
+      If you're in the ex_tauri repository root, try:
+        cd example
+        mix ex_tauri.build
+      """
+    end
+  end
+
   defp wrap() do
     get_in(Mix.Project.config(), [:releases, :desktop]) ||
-      raise "expected a burrito release configured for the app :desktop in your mix.exs"
+      raise "expected a :desktop release configured in your mix.exs"
 
     # Run release with MIX_ENV=prod at shell level to avoid including dev config with regexes.
     # Dev config (like live_reload patterns) contains regexes that can't be serialized.
@@ -179,19 +225,71 @@ defmodule ExTauri do
 
     # Burrito names output with underscores (desktop_x86_64-...) but Tauri expects
     # hyphens (desktop-x86_64-...). Get the host triple from rustc and rename.
+    rename_burrito_output()
+
+    :ok
+  end
+
+  defp wrap_dev() do
+    get_in(Mix.Project.config(), [:releases, :desktop]) ||
+      raise "expected a :desktop release configured in your mix.exs"
+
+    # Build a standard release without Burrito wrapping for faster dev iteration.
+    # Use MIX_ENV=prod to avoid serialization issues with dev config regexes.
+    case System.cmd("mix", ["release", "desktop", "--overwrite"],
+           env: [{"MIX_ENV", "prod"}, {"BURRITO_SKIP", "true"}],
+           into: IO.stream(:stdio, :line),
+           stderr_to_stdout: true
+         ) do
+      {_, 0} ->
+        :ok
+
+      {_, exit_code} ->
+        raise "Failed to build dev release with exit code #{exit_code}."
+    end
+
+    # Place the release binary where Tauri expects the sidecar.
+    # Tauri looks for burrito_out/desktop-<triplet>, so we create a
+    # wrapper script that launches the standard release.
+    ensure_dev_sidecar()
+
+    :ok
+  end
+
+  defp host_triplet do
     {rustc_output, 0} = System.cmd("rustc", ["-Vv"])
 
-    triplet =
-      case Regex.run(~r/host: (.+)/, rustc_output) do
-        [_, host] -> String.trim(host)
-        _ -> raise "Could not determine host triple from `rustc -Vv`"
-      end
+    case Regex.run(~r/host: (.+)/, rustc_output) do
+      [_, host] -> String.trim(host)
+      _ -> raise "Could not determine host triple from `rustc -Vv`"
+    end
+  end
+
+  defp rename_burrito_output do
+    triplet = host_triplet()
 
     File.cp!(
       "burrito_out/desktop_#{triplet}",
       "burrito_out/desktop-#{triplet}"
     )
+  end
 
-    :ok
+  defp ensure_dev_sidecar do
+    triplet = host_triplet()
+
+    File.mkdir_p!("burrito_out")
+
+    # Create a shell script that launches the standard release.
+    # The release binary is at _build/prod/rel/desktop/bin/desktop.
+    release_bin = Path.join([File.cwd!(), "_build", "prod", "rel", "desktop", "bin", "desktop"])
+    sidecar_path = "burrito_out/desktop-#{triplet}"
+
+    script = """
+    #!/bin/sh
+    exec "#{release_bin}" start "$@"
+    """
+
+    File.write!(sidecar_path, script)
+    File.chmod!(sidecar_path, 0o755)
   end
 end

--- a/lib/ex_tauri/clipboard.ex
+++ b/lib/ex_tauri/clipboard.ex
@@ -6,8 +6,23 @@ defmodule ExTauri.Clipboard do
 
   ## Requirements
 
-  - `tauri-plugin-clipboard-manager` must be installed
+  - `tauri-plugin-clipboard-manager` must be installed (see Plugin Setup below)
   - The `TauriHook` must be mounted in your LiveView (see `ExTauri.Hook`)
+
+  ## Plugin Setup
+
+  Add the dependency to `src-tauri/Cargo.toml`:
+
+      [dependencies]
+      tauri-plugin-clipboard-manager = "2"
+
+  Register the plugin in `src-tauri/src/main.rs` inside `tauri::Builder`:
+
+      .plugin(tauri_plugin_clipboard_manager::init())
+
+  Add the capability to `src-tauri/capabilities/default.json`:
+
+      "permissions": ["clipboard-manager:allow-write-text", "clipboard-manager:allow-read-text"]
 
   ## Examples
 

--- a/lib/ex_tauri/dialog.ex
+++ b/lib/ex_tauri/dialog.ex
@@ -6,8 +6,23 @@ defmodule ExTauri.Dialog do
 
   ## Requirements
 
-  - `tauri-plugin-dialog` must be installed
+  - `tauri-plugin-dialog` must be installed (see Plugin Setup below)
   - The `TauriHook` must be mounted in your LiveView (see `ExTauri.Hook`)
+
+  ## Plugin Setup
+
+  Add the dependency to `src-tauri/Cargo.toml`:
+
+      [dependencies]
+      tauri-plugin-dialog = "2"
+
+  Register the plugin in `src-tauri/src/main.rs` inside `tauri::Builder`:
+
+      .plugin(tauri_plugin_dialog::init())
+
+  Add the capability to `src-tauri/capabilities/default.json`:
+
+      "permissions": ["dialog:default"]
 
   ## Examples
 

--- a/lib/ex_tauri/filesystem.ex
+++ b/lib/ex_tauri/filesystem.ex
@@ -7,9 +7,31 @@ defmodule ExTauri.Filesystem do
 
   ## Requirements
 
-  - `tauri-plugin-fs` must be installed
+  - `tauri-plugin-fs` must be installed (see Plugin Setup below)
   - The `TauriHook` must be mounted in your LiveView (see `ExTauri.Hook`)
   - Appropriate filesystem permissions must be configured in capabilities
+
+  ## Plugin Setup
+
+  Add the dependency to `src-tauri/Cargo.toml`:
+
+      [dependencies]
+      tauri-plugin-fs = "2"
+
+  Register the plugin in `src-tauri/src/main.rs` inside `tauri::Builder`:
+
+      .plugin(tauri_plugin_fs::init())
+
+  Add the capability to `src-tauri/capabilities/default.json`:
+
+      "permissions": ["fs:default"]
+
+  For broader access, use scoped permissions:
+
+      {
+        "identifier": "fs:allow-read-text-file",
+        "allow": [{"path": "$APPDATA/**"}]
+      }
 
   ## Examples
 

--- a/lib/ex_tauri/hook.ex
+++ b/lib/ex_tauri/hook.ex
@@ -117,6 +117,47 @@ defmodule ExTauri.Hook do
   end
 
   @doc """
+  Pushes a Tauri command and tracks the `ref` in socket assigns for correlation.
+
+  This is useful when you need to distinguish between multiple concurrent
+  commands of the same type. The `ref` is stored under the given `assign_key`
+  in socket assigns, so you can match it in `handle_event/3`.
+
+  ## Examples
+
+      # Push and track
+      def handle_event("open_file_a", _params, socket) do
+        socket = ExTauri.Hook.push_command_tracked(socket, "dialog_open", %{title: "File A"}, :file_a_ref)
+        {:noreply, socket}
+      end
+
+      def handle_event("open_file_b", _params, socket) do
+        socket = ExTauri.Hook.push_command_tracked(socket, "dialog_open", %{title: "File B"}, :file_b_ref)
+        {:noreply, socket}
+      end
+
+      # Correlate the response
+      def handle_event("tauri_response", %{"ref" => ref} = params, socket) do
+        cond do
+          ref == socket.assigns[:file_a_ref] -> {:noreply, assign(socket, :file_a, params["path"])}
+          ref == socket.assigns[:file_b_ref] -> {:noreply, assign(socket, :file_b, params["path"])}
+          true -> {:noreply, socket}
+        end
+      end
+  """
+  def push_command_tracked(socket, command, payload, assign_key) do
+    ref = System.unique_integer([:positive]) |> to_string()
+
+    socket
+    |> Phoenix.LiveView.assign(assign_key, ref)
+    |> Phoenix.LiveView.push_event("tauri_command", %{
+      ref: ref,
+      command: command,
+      payload: payload
+    })
+  end
+
+  @doc """
   Returns the JavaScript source code for the TauriHook.
 
   This can be used to generate the vendor file at build time or

--- a/lib/ex_tauri/install/helpers.ex
+++ b/lib/ex_tauri/install/helpers.ex
@@ -2,6 +2,9 @@ defmodule ExTauri.Install.Helpers do
   @moduledoc false
   # Shared helper functions for Tauri project setup.
 
+  @main_rs_template Path.join(:code.priv_dir(:ex_tauri), "templates/main.rs.eex")
+  @external_resource @main_rs_template
+
   @doc """
   Installs the Tauri CLI via cargo and initializes the Tauri project structure.
   """
@@ -114,13 +117,6 @@ defmodule ExTauri.Install.Helpers do
       Path.join([src_tauri, "src", "main.rs"]),
       main_src(config.host, config.port, config.sanitized_name)
     )
-
-    # Workaround: tauri init places build.rs in src-tauri/ but it needs to be
-    # in src-tauri/src/ for the build to find it. See Cargo.toml build = "src/build.rs"
-    File.cp!(
-      Path.join(src_tauri, "build.rs"),
-      Path.join([src_tauri, "src", "build.rs"])
-    )
   end
 
   # ── Tauri JSON configuration ───────────────────────────────────────────────
@@ -129,31 +125,41 @@ defmodule ExTauri.Install.Helpers do
     conf_path = Path.join([File.cwd!(), "src-tauri", "tauri.conf.json"])
     identifier = config.sanitized_name |> String.replace("_", "-")
 
-    conf_path
-    |> File.read!()
-    |> Jason.decode!()
-    |> Map.merge(%{
-      "productName" => config.app_name,
-      "identifier" => "you.app.#{identifier}"
-    })
-    |> put_in(["bundle", "externalBin"], ["../burrito_out/desktop"])
-    |> put_in(["app", "security"], %{
-      "csp" =>
-        "default-src 'self'; script-src 'self' 'unsafe-inline'; " <>
-          "style-src 'self' 'unsafe-inline'; " <>
-          "connect-src 'self' ipc: tauri: ws: wss:; " <>
-          "img-src 'self' data: asset: tauri:; " <>
-          "font-src 'self' data:"
-    })
-    |> put_in(["app", "windows"], [
-      %{
-        title: config.window_title,
-        fullscreen: config.fullscreen,
-        width: config.width,
-        height: config.height,
-        resizable: config.resize
-      }
-    ])
+    tauri_conf =
+      conf_path
+      |> File.read!()
+      |> Jason.decode!()
+      |> Map.merge(%{
+        "productName" => config.app_name,
+        "identifier" => "you.app.#{identifier}"
+      })
+      |> put_in(["bundle", "externalBin"], ["../burrito_out/desktop"])
+      |> put_in(["app", "security"], %{
+        "csp" =>
+          "default-src 'self'; script-src 'self' 'unsafe-inline'; " <>
+            "style-src 'self' 'unsafe-inline'; " <>
+            "connect-src 'self' ipc: tauri: ws: wss:; " <>
+            "img-src 'self' data: asset: tauri:; " <>
+            "font-src 'self' data:"
+      })
+      |> put_in(["app", "windows"], [
+        %{
+          title: config.window_title,
+          fullscreen: config.fullscreen,
+          width: config.width,
+          height: config.height,
+          resizable: config.resize
+        }
+      ])
+
+    # Merge updater config if enabled
+    tauri_conf =
+      case ExTauri.Updater.tauri_config() do
+        config when config == %{} -> tauri_conf
+        updater_config -> Map.merge(tauri_conf, updater_config)
+      end
+
+    tauri_conf
     |> Jason.encode!(pretty: true)
     |> then(&File.write!(conf_path, &1))
   end
@@ -320,7 +326,6 @@ defmodule ExTauri.Install.Helpers do
     version = "0.1.0"
     default-run = "#{sanitized}"
     edition = "2021"
-    build = "src/build.rs"
     description = ""
 
     [build-dependencies]
@@ -347,241 +352,12 @@ defmodule ExTauri.Install.Helpers do
   @doc false
   def main_src(host, port, socket_name) do
     validate_rust_interpolations!(host, port, socket_name)
-    port_str = to_string(port)
 
-    """
-    // Prevents additional console window on Windows in release, DO NOT REMOVE!!
-    #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
-    use tauri_plugin_shell::process::CommandEvent;
-    use tauri_plugin_shell::ShellExt;
-    use tauri::Manager;
-
-    use std::sync::Mutex;
-    use std::time::Duration;
-
-    struct AppState {
-        sidecar_child: Mutex<Option<SidecarProcess>>,
-    }
-
-    struct SidecarProcess {
-        child: Option<tauri_plugin_shell::process::CommandChild>,
-        pid: Option<u32>,
-    }
-
-    impl Drop for SidecarProcess {
-        fn drop(&mut self) {
-            if let Some(child) = self.child.take() {
-                let _ = child.kill();
-            }
-        }
-    }
-
-    fn kill_sidecar(app: &tauri::AppHandle) {
-        if let Some(state) = app.try_state::<AppState>() {
-            if let Ok(mut guard) = state.sidecar_child.lock() {
-                if let Some(mut process) = guard.take() {
-                    // Try graceful shutdown first with SIGTERM
-                    if let Some(pid) = process.pid {
-                        println!("Attempting graceful shutdown of sidecar (PID: {})...", pid);
-
-                        // Send SIGTERM for graceful shutdown
-                        #[cfg(unix)]
-                        {
-                            use std::process::Command;
-                            let _ = Command::new("kill")
-                                .args(["-TERM", &pid.to_string()])
-                                .output();
-
-                            // Wait up to 2 seconds for graceful shutdown
-                            let timeout = Duration::from_millis(2000);
-                            let start = std::time::Instant::now();
-
-                            while start.elapsed() < timeout {
-                                // Check if process is still running
-                                let status = Command::new("kill")
-                                    .args(["-0", &pid.to_string()])
-                                    .output();
-
-                                if let Ok(output) = status {
-                                    if !output.status.success() {
-                                        println!("Sidecar shut down gracefully");
-                                        return;
-                                    }
-                                }
-
-                                std::thread::sleep(Duration::from_millis(100));
-                            }
-
-                            println!("Graceful shutdown timeout, forcing kill...");
-                        }
-
-                        #[cfg(windows)]
-                        {
-                            // On Windows, wait a bit for graceful shutdown
-                            std::thread::sleep(Duration::from_millis(2000));
-                        }
-                    }
-
-                    // Fallback to SIGKILL if graceful shutdown didn't work
-                    if let Some(child) = process.child.take() {
-                        println!("Sending SIGKILL to sidecar...");
-                        let _ = child.kill();
-                    }
-                }
-            }
-        }
-    }
-
-    fn main() {
-        tauri::Builder::default()
-            .plugin(tauri_plugin_single_instance::init(|_app, _args, _cwd| {
-                // Focus the main window when a second instance is launched
-            }))
-            .plugin(tauri_plugin_shell::init())
-            .plugin(tauri_plugin_log::Builder::new().build())
-            .plugin(tauri_plugin_notification::init())
-            .manage(AppState {
-                sidecar_child: Mutex::new(None),
-            })
-            .setup(|app| {
-                start_server(app.handle());
-                check_server_started();
-                start_heartbeat();
-                Ok(())
-            })
-            // Intercept menu events (especially CMD+Q on macOS)
-            .on_menu_event(|app, event| {
-                println!("Menu event received: {:?}", event.id());
-                // On macOS, the default menu includes a "quit" item
-                // Intercept it to perform graceful shutdown
-                if event.id().as_ref() == "quit" || event.id().as_ref().contains("quit") {
-                    println!("Quit menu item clicked (CMD+Q), shutting down gracefully...");
-                    kill_sidecar(app);
-                    std::thread::sleep(std::time::Duration::from_millis(500));
-                    std::process::exit(0);
-                }
-            })
-            .on_window_event(|window, event| {
-                if let tauri::WindowEvent::CloseRequested { .. } = event {
-                    // Kill the sidecar when the window closes
-                    kill_sidecar(&window.app_handle());
-                }
-            })
-            .build(tauri::generate_context!())
-            .expect("error while building tauri application")
-            .run(|app_handle, event| {
-                if let tauri::RunEvent::ExitRequested { api, .. } = event {
-                    // Kill the sidecar when the app is exiting (fallback for non-menu exits)
-                    println!("ExitRequested event received, shutting down...");
-                    kill_sidecar(app_handle);
-                    api.prevent_exit(); // Prevent exit until we've cleaned up
-                    // Allow exit after cleanup
-                    std::thread::spawn(move || {
-                        std::thread::sleep(std::time::Duration::from_millis(500));
-                        std::process::exit(0);
-                    });
-                }
-            });
-    }
-
-    fn start_server(app: &tauri::AppHandle) {
-        let sidecar_command = app.shell().sidecar("desktop")
-            .expect("failed to setup `desktop` sidecar");
-
-        let (mut rx, child) = sidecar_command
-            .spawn()
-            .expect("Failed to spawn desktop sidecar");
-
-        // Get the PID for graceful shutdown
-        let pid = child.pid();
-        println!("Sidecar process started with PID: {}", pid);
-
-        // Store the child process handle so we can kill it on exit
-        if let Some(state) = app.try_state::<AppState>() {
-            if let Ok(mut guard) = state.sidecar_child.lock() {
-                *guard = Some(SidecarProcess {
-                    child: Some(child),
-                    pid: Some(pid),
-                });
-            }
-        }
-
-        tauri::async_runtime::spawn(async move {
-            while let Some(event) = rx.recv().await {
-                if let CommandEvent::Stdout(line_bytes) = event {
-                    let line = String::from_utf8_lossy(&line_bytes);
-                    println!("{}", line);
-                }
-            }
-        });
-    }
-
-    fn check_server_started() {
-        let sleep_interval = std::time::Duration::from_millis(200);
-        let host = "#{host}".to_string();
-        let port = "#{port_str}".to_string();
-        let addr = format!("{}:{}", host, port);
-        println!(
-            "Waiting for your phoenix dev server to start on {}...",
-            addr
-        );
-        loop {
-            if std::net::TcpStream::connect(addr.clone()).is_ok() {
-               break;
-            }
-            std::thread::sleep(sleep_interval);
-        }
-    }
-
-    fn start_heartbeat() {
-        println!("Starting heartbeat to Phoenix sidecar...");
-
-        std::thread::spawn(|| {
-            use std::io::Write;
-
-            let socket_path = std::env::temp_dir().join("tauri_heartbeat_#{socket_name}.sock");
-            let interval = Duration::from_millis(100);
-
-            #[cfg(unix)]
-            {
-                use std::os::unix::net::UnixStream;
-
-                // Wait for socket to be ready
-                let mut stream = loop {
-                    match UnixStream::connect(&socket_path) {
-                        Ok(s) => break s,
-                        Err(_) => {
-                            // Socket not ready yet, wait and retry
-                            std::thread::sleep(Duration::from_millis(100));
-                        }
-                    }
-                };
-
-                println!("Connected to heartbeat socket");
-
-                loop {
-                    match stream.write_all(b"h") {
-                        Ok(_) => {}
-                        Err(_) => {
-                            // Connection lost, sidecar likely shut down
-                            break;
-                        }
-                    }
-
-                    std::thread::sleep(interval);
-                }
-            }
-
-            #[cfg(windows)]
-            {
-                // Windows: use named pipe or TCP fallback for heartbeat
-                // TODO: Implement Windows named pipe heartbeat
-                println!("Heartbeat not yet supported on Windows");
-            }
-        });
-    }
-
-    """
+    EEx.eval_file(@main_rs_template,
+      host: to_string(host),
+      port: to_string(port),
+      socket_name: to_string(socket_name)
+    )
   end
 
   defp validate_rust_interpolations!(host, port, socket_name) do

--- a/lib/ex_tauri/notification.ex
+++ b/lib/ex_tauri/notification.ex
@@ -7,9 +7,15 @@ defmodule ExTauri.Notification do
 
   ## Requirements
 
-  - `tauri-plugin-notification` must be installed (added by `mix ex_tauri.install`)
+  - `tauri-plugin-notification` must be installed (included by `mix ex_tauri.install`)
   - The `TauriHook` must be mounted in your LiveView (see `ExTauri.Hook`)
   - The `notification:default` capability must be configured
+
+  ## Plugin Setup
+
+  This plugin is included by default when running `mix ex_tauri.install`.
+  The `notification:default` capability is already configured in the
+  generated `src-tauri/capabilities/default.json`. No additional setup needed.
 
   ## Examples
 

--- a/lib/ex_tauri/os.ex
+++ b/lib/ex_tauri/os.ex
@@ -6,8 +6,23 @@ defmodule ExTauri.OS do
 
   ## Requirements
 
-  - `tauri-plugin-os` must be installed
+  - `tauri-plugin-os` must be installed (see Plugin Setup below)
   - The `TauriHook` must be mounted in your LiveView (see `ExTauri.Hook`)
+
+  ## Plugin Setup
+
+  Add the dependency to `src-tauri/Cargo.toml`:
+
+      [dependencies]
+      tauri-plugin-os = "2"
+
+  Register the plugin in `src-tauri/src/main.rs` inside `tauri::Builder`:
+
+      .plugin(tauri_plugin_os::init())
+
+  Add the capability to `src-tauri/capabilities/default.json`:
+
+      "permissions": ["os:default"]
 
   ## Examples
 

--- a/lib/ex_tauri/paths.ex
+++ b/lib/ex_tauri/paths.ex
@@ -8,12 +8,12 @@ defmodule ExTauri.Paths do
 
   ## Paths by Platform
 
-  | Function      | macOS                                    | Linux                              |
-  |---------------|------------------------------------------|------------------------------------|
-  | `data_dir/0`  | `~/Library/Application Support/<app>`    | `~/.local/share/<app>`             |
-  | `config_dir/0`| `~/Library/Application Support/<app>`    | `~/.config/<app>`                  |
-  | `cache_dir/0` | `~/Library/Caches/<app>`                 | `~/.cache/<app>`                   |
-  | `log_dir/0`   | `~/Library/Logs/<app>`                   | `~/.local/state/<app>/log`         |
+  | Function      | macOS                                    | Linux                              | Windows                            |
+  |---------------|------------------------------------------|------------------------------------|------------------------------------|
+  | `data_dir/0`  | `~/Library/Application Support/<app>`    | `~/.local/share/<app>`             | `%APPDATA%/<app>`                  |
+  | `config_dir/0`| `~/Library/Application Support/<app>`    | `~/.config/<app>`                  | `%APPDATA%/<app>`                  |
+  | `cache_dir/0` | `~/Library/Caches/<app>`                 | `~/.cache/<app>`                   | `%LOCALAPPDATA%/<app>/cache`       |
+  | `log_dir/0`   | `~/Library/Logs/<app>`                   | `~/.local/state/<app>/log`         | `%LOCALAPPDATA%/<app>/log`         |
 
   All directories are created automatically if they don't exist.
 
@@ -109,6 +109,10 @@ defmodule ExTauri.Paths do
 
       {:unix, _} ->
         xdg_or_default("XDG_DATA_HOME", ".local/share")
+
+      {:win32, _} ->
+        appdata = System.get_env("APPDATA") || Path.join(System.user_home!(), "AppData/Roaming")
+        Path.join(appdata, app_identifier())
     end
   end
 
@@ -119,6 +123,10 @@ defmodule ExTauri.Paths do
 
       {:unix, _} ->
         xdg_or_default("XDG_CONFIG_HOME", ".config")
+
+      {:win32, _} ->
+        appdata = System.get_env("APPDATA") || Path.join(System.user_home!(), "AppData/Roaming")
+        Path.join(appdata, app_identifier())
     end
   end
 
@@ -129,6 +137,10 @@ defmodule ExTauri.Paths do
 
       {:unix, _} ->
         xdg_or_default("XDG_CACHE_HOME", ".cache")
+
+      {:win32, _} ->
+        local = System.get_env("LOCALAPPDATA") || Path.join(System.user_home!(), "AppData/Local")
+        Path.join([local, app_identifier(), "cache"])
     end
   end
 
@@ -140,6 +152,10 @@ defmodule ExTauri.Paths do
       {:unix, _} ->
         xdg_or_default("XDG_STATE_HOME", ".local/state")
         |> Path.join("log")
+
+      {:win32, _} ->
+        local = System.get_env("LOCALAPPDATA") || Path.join(System.user_home!(), "AppData/Local")
+        Path.join([local, app_identifier(), "log"])
     end
   end
 

--- a/lib/ex_tauri/shell.ex
+++ b/lib/ex_tauri/shell.ex
@@ -6,9 +6,27 @@ defmodule ExTauri.Shell do
 
   ## Requirements
 
-  - `tauri-plugin-shell` must be installed
+  - `tauri-plugin-shell` must be installed (included by `mix ex_tauri.install`)
   - The `TauriHook` must be mounted in your LiveView (see `ExTauri.Hook`)
   - Shell commands must be allowed in your Tauri capabilities configuration
+
+  ## Plugin Setup
+
+  This plugin is included by default when running `mix ex_tauri.install`.
+  To allowlist additional shell commands, add scoped permissions to
+  `src-tauri/capabilities/default.json`:
+
+      {
+        "identifier": "shell:allow-execute",
+        "allow": [
+          {"name": "git", "cmd": "git", "args": true},
+          {"name": "node", "cmd": "node", "args": ["--version"]}
+        ]
+      }
+
+  To allow opening URLs in the default browser:
+
+      "permissions": ["shell:allow-open"]
 
   ## Security Note
 

--- a/lib/ex_tauri/shutdown_manager.ex
+++ b/lib/ex_tauri/shutdown_manager.ex
@@ -85,8 +85,8 @@ defmodule ExTauri.ShutdownManager do
     # Restrict socket to owner-only access (prevents local privilege escalation)
     File.chmod(socket_path, 0o600)
 
-    # Spawn acceptor process with link for proper supervision
-    Task.start_link(fn -> accept_loop(listen_socket) end)
+    # Spawn acceptor process under the ExTauri TaskSupervisor
+    Task.Supervisor.start_child(ExTauri.TaskSupervisor, fn -> accept_loop(listen_socket) end)
 
     # Schedule the first heartbeat check
     schedule_heartbeat_check(heartbeat_interval)
@@ -161,8 +161,8 @@ defmodule ExTauri.ShutdownManager do
   defp accept_loop(listen_socket) do
     case :gen_tcp.accept(listen_socket, 1000) do
       {:ok, client_socket} ->
-        # Spawn a linked process to handle this client
-        Task.start_link(fn -> handle_client(client_socket) end)
+        # Spawn client handler under the TaskSupervisor
+        Task.Supervisor.start_child(ExTauri.TaskSupervisor, fn -> handle_client(client_socket) end)
         # Continue accepting more connections
         accept_loop(listen_socket)
 

--- a/lib/ex_tauri/task_helpers.ex
+++ b/lib/ex_tauri/task_helpers.ex
@@ -24,6 +24,38 @@ defmodule ExTauri.TaskHelpers do
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
       """)
     end
+
+    check_otp_version()
+  end
+
+  @doc """
+  Warns if the OTP version is not compatible with Burrito's ERTS availability.
+  """
+  def check_otp_version do
+    otp_release = :erlang.system_info(:otp_release) |> List.to_string()
+
+    case Integer.parse(otp_release) do
+      {major, _} when major < 27 ->
+        Mix.raise("""
+        ExTauri requires OTP 27 but you are running OTP #{otp_release}.
+        Burrito does not have pre-compiled ERTS available for other versions.
+
+        Install OTP 27 via your version manager:
+
+            asdf install erlang 27.2
+            mise install erlang 27.2
+        """)
+
+      {major, _} when major > 27 ->
+        Mix.shell().info("""
+        Warning: ExTauri targets OTP 27 but you are running OTP #{otp_release}.
+        Burrito may not have pre-compiled ERTS for OTP #{major} yet.
+        Development should work, but production builds may fail.
+        """)
+
+      _ ->
+        :ok
+    end
   end
 
   @doc """

--- a/lib/mix/tasks/ex_tauri.dev.ex
+++ b/lib/mix/tasks/ex_tauri.dev.ex
@@ -86,6 +86,6 @@ defmodule Mix.Tasks.ExTauri.Dev do
       ["--no-dev-server-wait"] ++
         ExTauri.TaskHelpers.build_tauri_args(@flag_specs, opts, extra_args)
 
-    ExTauri.run(["dev" | tauri_args])
+    ExTauri.run_dev(["dev" | tauri_args])
   end
 end

--- a/priv/static/ex_tauri.js
+++ b/priv/static/ex_tauri.js
@@ -164,16 +164,41 @@ async function execCommand(command, payload) {
 
 export const TauriHook = {
   mounted() {
+    this._setupCommandHandler();
+  },
+
+  // Re-attach the event handler when LiveView reconnects after a disconnect.
+  // Without this, commands pushed after reconnection would be silently dropped.
+  reconnected() {
+    this._setupCommandHandler();
+  },
+
+  // Clean up any in-flight state when the hook element is removed from the DOM.
+  destroyed() {
+    this._destroyed = true;
+  },
+
+  _setupCommandHandler() {
+    this._destroyed = false;
+
     this.handleEvent("tauri_command", async ({ ref, command, payload }) => {
+      // Guard against responses being pushed after the hook was destroyed
+      // (e.g., a slow dialog resolved after navigation).
+      if (this._destroyed) return;
+
       try {
         const result = await execCommand(command, payload);
-        this.pushEvent("tauri_response", { ref, command, ...result });
+        if (!this._destroyed) {
+          this.pushEvent("tauri_response", { ref, command, ...result });
+        }
       } catch (error) {
-        this.pushEvent("tauri_error", {
-          ref,
-          command,
-          error: error.message || String(error),
-        });
+        if (!this._destroyed) {
+          this.pushEvent("tauri_error", {
+            ref,
+            command,
+            error: error.message || String(error),
+          });
+        }
       }
     });
   },

--- a/priv/templates/main.rs.eex
+++ b/priv/templates/main.rs.eex
@@ -1,0 +1,230 @@
+// Prevents additional console window on Windows in release, DO NOT REMOVE!!
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+use tauri_plugin_shell::process::CommandEvent;
+use tauri_plugin_shell::ShellExt;
+use tauri::Manager;
+
+use std::sync::Mutex;
+use std::time::Duration;
+
+struct AppState {
+    sidecar_child: Mutex<Option<SidecarProcess>>,
+}
+
+struct SidecarProcess {
+    child: Option<tauri_plugin_shell::process::CommandChild>,
+    pid: Option<u32>,
+}
+
+impl Drop for SidecarProcess {
+    fn drop(&mut self) {
+        if let Some(child) = self.child.take() {
+            let _ = child.kill();
+        }
+    }
+}
+
+fn kill_sidecar(app: &tauri::AppHandle) {
+    if let Some(state) = app.try_state::<AppState>() {
+        if let Ok(mut guard) = state.sidecar_child.lock() {
+            if let Some(mut process) = guard.take() {
+                // Try graceful shutdown first with SIGTERM
+                if let Some(pid) = process.pid {
+                    println!("Attempting graceful shutdown of sidecar (PID: {})...", pid);
+
+                    // Send SIGTERM for graceful shutdown
+                    #[cfg(unix)]
+                    {
+                        use std::process::Command;
+                        let _ = Command::new("kill")
+                            .args(["-TERM", &pid.to_string()])
+                            .output();
+
+                        // Wait up to 2 seconds for graceful shutdown
+                        let timeout = Duration::from_millis(2000);
+                        let start = std::time::Instant::now();
+
+                        while start.elapsed() < timeout {
+                            // Check if process is still running
+                            let status = Command::new("kill")
+                                .args(["-0", &pid.to_string()])
+                                .output();
+
+                            if let Ok(output) = status {
+                                if !output.status.success() {
+                                    println!("Sidecar shut down gracefully");
+                                    return;
+                                }
+                            }
+
+                            std::thread::sleep(Duration::from_millis(100));
+                        }
+
+                        println!("Graceful shutdown timeout, forcing kill...");
+                    }
+
+                    #[cfg(windows)]
+                    {
+                        // On Windows, wait a bit for graceful shutdown
+                        std::thread::sleep(Duration::from_millis(2000));
+                    }
+                }
+
+                // Fallback to SIGKILL if graceful shutdown didn't work
+                if let Some(child) = process.child.take() {
+                    println!("Sending SIGKILL to sidecar...");
+                    let _ = child.kill();
+                }
+            }
+        }
+    }
+}
+
+fn main() {
+    tauri::Builder::default()
+        .plugin(tauri_plugin_single_instance::init(|_app, _args, _cwd| {
+            // Focus the main window when a second instance is launched
+        }))
+        .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_log::Builder::new().build())
+        .plugin(tauri_plugin_notification::init())
+        .manage(AppState {
+            sidecar_child: Mutex::new(None),
+        })
+        .setup(|app| {
+            start_server(app.handle());
+            check_server_started();
+            start_heartbeat();
+            Ok(())
+        })
+        // Intercept menu events (especially CMD+Q on macOS)
+        .on_menu_event(|app, event| {
+            println!("Menu event received: {:?}", event.id());
+            // On macOS, the default menu includes a "quit" item
+            // Intercept it to perform graceful shutdown
+            if event.id().as_ref() == "quit" || event.id().as_ref().contains("quit") {
+                println!("Quit menu item clicked (CMD+Q), shutting down gracefully...");
+                kill_sidecar(app);
+                std::thread::sleep(std::time::Duration::from_millis(500));
+                std::process::exit(0);
+            }
+        })
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::CloseRequested { .. } = event {
+                // Kill the sidecar when the window closes
+                kill_sidecar(&window.app_handle());
+            }
+        })
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app_handle, event| {
+            if let tauri::RunEvent::ExitRequested { api, .. } = event {
+                // Kill the sidecar when the app is exiting (fallback for non-menu exits)
+                println!("ExitRequested event received, shutting down...");
+                kill_sidecar(app_handle);
+                api.prevent_exit(); // Prevent exit until we've cleaned up
+                // Allow exit after cleanup
+                std::thread::spawn(move || {
+                    std::thread::sleep(std::time::Duration::from_millis(500));
+                    std::process::exit(0);
+                });
+            }
+        });
+}
+
+fn start_server(app: &tauri::AppHandle) {
+    let sidecar_command = app.shell().sidecar("desktop")
+        .expect("failed to setup `desktop` sidecar");
+
+    let (mut rx, child) = sidecar_command
+        .spawn()
+        .expect("Failed to spawn desktop sidecar");
+
+    // Get the PID for graceful shutdown
+    let pid = child.pid();
+    println!("Sidecar process started with PID: {}", pid);
+
+    // Store the child process handle so we can kill it on exit
+    if let Some(state) = app.try_state::<AppState>() {
+        if let Ok(mut guard) = state.sidecar_child.lock() {
+            *guard = Some(SidecarProcess {
+                child: Some(child),
+                pid: Some(pid),
+            });
+        }
+    }
+
+    tauri::async_runtime::spawn(async move {
+        while let Some(event) = rx.recv().await {
+            if let CommandEvent::Stdout(line_bytes) = event {
+                let line = String::from_utf8_lossy(&line_bytes);
+                println!("{}", line);
+            }
+        }
+    });
+}
+
+fn check_server_started() {
+    let sleep_interval = std::time::Duration::from_millis(200);
+    let host = "<%= host %>".to_string();
+    let port = "<%= port %>".to_string();
+    let addr = format!("{}:{}", host, port);
+    println!(
+        "Waiting for your phoenix dev server to start on {}...",
+        addr
+    );
+    loop {
+        if std::net::TcpStream::connect(addr.clone()).is_ok() {
+           break;
+        }
+        std::thread::sleep(sleep_interval);
+    }
+}
+
+fn start_heartbeat() {
+    println!("Starting heartbeat to Phoenix sidecar...");
+
+    std::thread::spawn(|| {
+        use std::io::Write;
+
+        let socket_path = std::env::temp_dir().join("tauri_heartbeat_<%= socket_name %>.sock");
+        let interval = Duration::from_millis(100);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::net::UnixStream;
+
+            // Wait for socket to be ready
+            let mut stream = loop {
+                match UnixStream::connect(&socket_path) {
+                    Ok(s) => break s,
+                    Err(_) => {
+                        // Socket not ready yet, wait and retry
+                        std::thread::sleep(Duration::from_millis(100));
+                    }
+                }
+            };
+
+            println!("Connected to heartbeat socket");
+
+            loop {
+                match stream.write_all(b"h") {
+                    Ok(_) => {}
+                    Err(_) => {
+                        // Connection lost, sidecar likely shut down
+                        break;
+                    }
+                }
+
+                std::thread::sleep(interval);
+            }
+        }
+
+        #[cfg(windows)]
+        {
+            // Windows: use named pipe or TCP fallback for heartbeat
+            // TODO: Implement Windows named pipe heartbeat
+            println!("Heartbeat not yet supported on Windows");
+        }
+    });
+}

--- a/test/ex_tauri_e2e_test.exs
+++ b/test/ex_tauri_e2e_test.exs
@@ -88,7 +88,7 @@ defmodule ExTauri.E2ETest do
 
       File.write!(Path.join(src_tauri, "Cargo.toml"), cargo_toml)
       File.write!(Path.join(src_dir, "main.rs"), main_rs)
-      File.write!(Path.join(src_dir, "build.rs"), build_rs)
+      File.write!(Path.join(src_tauri, "build.rs"), build_rs)
       File.write!(Path.join(src_tauri, "tauri.conf.json"), tauri_conf)
       File.write!(Path.join(capabilities_dir, "default.json"), capabilities)
 

--- a/test/ex_tauri_integration_test.exs
+++ b/test/ex_tauri_integration_test.exs
@@ -18,7 +18,6 @@ defmodule ExTauriIntegrationTest do
       assert cargo_toml =~ ~r/name = "test_app"/
       assert cargo_toml =~ ~r/version = "0\.1\.0"/
       assert cargo_toml =~ ~r/edition = "2021"/
-      assert cargo_toml =~ ~r/build = "src\/build\.rs"/
 
       # Verify build dependencies use semver major version (not exact version)
       assert cargo_toml =~ ~r/\[build-dependencies\]/


### PR DESCRIPTION
- Remove macOS-only Burrito cache deletion that slowed every dev build
- Add Windows path support to ExTauri.Paths (%APPDATA%, %LOCALAPPDATA%)
- Move Rust main.rs from inline string to priv/templates/main.rs.eex
- Remove build.rs copy hack by using Cargo's default build script path
- Wire ExTauri.Updater config into tauri.conf.json generation
- Add plugin installation docs to Dialog, Clipboard, FS, OS, Shell modules
- Add push_command_tracked/4 for ref-based response correlation
- Replace empty OTP supervisor with Task.Supervisor for socket tasks
- Use Task.Supervisor in ShutdownManager for accept/client loops
- Add "Using Desktop APIs" section and Ecto migration guide to README
- Update REVIEW.md to reflect resolved issues and remaining work
- Fix tests for Cargo.toml build.rs path change

https://claude.ai/code/session_01LcSNRN6NSZqC3VmpBdGxGi